### PR TITLE
Fix issue #12 (anvil combine/repair bug with leveled items)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,15 +11,12 @@ repositories {
     maven {
         url = uri('https://hub.spigotmc.org/nexus/content/repositories/snapshots/')
     }
-
     maven {
         url = uri('https://oss.sonatype.org/content/groups/public/')
     }
-
     maven {
         url = uri('https://repo.codemc.org/repository/maven-public/')
     }
-
     maven {
         url = uri('https://repo.maven.apache.org/maven2/')
     }
@@ -30,9 +27,8 @@ repositories {
 
 dependencies {
     implementation 'de.tr7zw:item-nbt-api:2.8.0'
-    implementation 'me.lucko:helper:5.6.8'
-    implementation 'com.github.Redempt:RedLib:6.1.0.3'
-    implementation 'com.github.cryptomorin:XSeries:8.4.0'
+    implementation 'com.github.Redempt:RedLib:6.3.0.4'
+    implementation 'com.github.cryptomorin:XSeries:8.5.0.1'
 
     compileOnly 'org.spigotmc:spigot-api:1.14.4-R0.1-SNAPSHOT'
     compileOnly 'org.jetbrains:annotations:22.0.0'
@@ -56,7 +52,6 @@ shadowJar {
     archiveClassifier.set("")
 
     relocate "de.tr7zw.changeme.nbtapi", "me.byteful.plugin.leveltools.libs.nbtapi"
-    relocate "me.lucko", "me.byteful.plugin.leveltools.libs.lucko"
     relocate "com.cryptomorin.xseries", "me.byteful.plugin.leveltools.libs.xseries"
     relocate "redempt.redlib", "me.byteful.plugin.leveltools.libs.redlib"
 }

--- a/src/main/java/me/byteful/plugin/leveltools/LevelToolsPlugin.java
+++ b/src/main/java/me/byteful/plugin/leveltools/LevelToolsPlugin.java
@@ -1,28 +1,32 @@
 package me.byteful.plugin.leveltools;
 
+import me.byteful.plugin.leveltools.api.AnvilCombineMode;
+import me.byteful.plugin.leveltools.listeners.AnvilListener;
 import me.byteful.plugin.leveltools.listeners.BlockEventListener;
 import me.byteful.plugin.leveltools.listeners.EntityEventListener;
-import me.lucko.helper.Commands;
-import me.lucko.helper.command.CommandInterruptException;
-import me.lucko.helper.plugin.ExtendedJavaPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
 import redempt.redlib.blockdata.BlockDataManager;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Objects;
 
-public final class LevelToolsPlugin extends ExtendedJavaPlugin {
+public final class LevelToolsPlugin extends JavaPlugin {
   private static LevelToolsPlugin instance;
 
   private BlockDataManager blockDataManager;
+  private AnvilCombineMode anvilCombineMode;
 
   public static LevelToolsPlugin getInstance() {
     return instance;
   }
 
   @Override
-  protected void enable() {
+  public void onEnable() {
     instance = this;
 
     if (!getDataFolder().exists()) {
@@ -59,6 +63,7 @@ public final class LevelToolsPlugin extends ExtendedJavaPlugin {
     getLogger().info("Loaded BlockDataManager...");
 
     saveDefaultConfig();
+    anvilCombineMode = AnvilCombineMode.fromName(Objects.requireNonNull(getConfig().getString("anvil_combine")));
     getLogger().info("Loaded configuration...");
 
     registerListeners();
@@ -71,7 +76,7 @@ public final class LevelToolsPlugin extends ExtendedJavaPlugin {
   }
 
   @Override
-  protected void disable() {
+  public void onDisable() {
     if (blockDataManager != null) {
       blockDataManager.saveAndClose();
       blockDataManager = null;
@@ -83,28 +88,30 @@ public final class LevelToolsPlugin extends ExtendedJavaPlugin {
   }
 
   private void registerListeners() {
-    registerListener(new BlockEventListener());
-    registerListener(new EntityEventListener());
+    final PluginManager pm = Bukkit.getPluginManager();
+    pm.registerEvents(new BlockEventListener(), this);
+    pm.registerEvents(new EntityEventListener(), this);
+    pm.registerEvents(new AnvilListener(), this);
   }
 
   private void registerReloadCommand() {
-    Commands.create()
-        .description("Reloads the configuration for LevelTools.")
-        .handler(
-            c -> {
-              if (!c.sender().hasPermission("leveltools.admin")) {
-                throw new CommandInterruptException(
-                    getConfig().getString("messages.no_permission"));
-              }
+    Objects.requireNonNull(getCommand("lt-reload")).setExecutor((sender, command, label, args) -> {
+      if (!sender.hasPermission("leveltools.admin")) {
+        sender.sendMessage(Text.colorize(Objects.requireNonNull(getConfig().getString("messages.no_permission"))));
+      }
 
-              reloadConfig();
+      reloadConfig();
+      sender.sendMessage(Text.colorize(Objects.requireNonNull(getConfig().getString("messages.successful_reload"))));
 
-              c.reply(getConfig().getString("messages.successful_reload"));
-            })
-        .register("leveltools-reload", "lt-reload");
+      return true;
+    });
   }
 
   public BlockDataManager getBlockDataManager() {
     return blockDataManager;
+  }
+
+  public AnvilCombineMode getAnvilCombineMode() {
+    return anvilCombineMode;
   }
 }

--- a/src/main/java/me/byteful/plugin/leveltools/LevelToolsPlugin.java
+++ b/src/main/java/me/byteful/plugin/leveltools/LevelToolsPlugin.java
@@ -63,7 +63,8 @@ public final class LevelToolsPlugin extends JavaPlugin {
     getLogger().info("Loaded BlockDataManager...");
 
     saveDefaultConfig();
-    anvilCombineMode = AnvilCombineMode.fromName(Objects.requireNonNull(getConfig().getString("anvil_combine")));
+    getConfig().options().copyDefaults(true).copyHeader(true);
+    setAnvilCombineMode();
     getLogger().info("Loaded configuration...");
 
     registerListeners();
@@ -94,6 +95,10 @@ public final class LevelToolsPlugin extends JavaPlugin {
     pm.registerEvents(new AnvilListener(), this);
   }
 
+  private void setAnvilCombineMode() {
+    anvilCombineMode = AnvilCombineMode.fromName(Objects.requireNonNull(getConfig().getString("anvil_combine")));
+  }
+
   private void registerReloadCommand() {
     Objects.requireNonNull(getCommand("lt-reload")).setExecutor((sender, command, label, args) -> {
       if (!sender.hasPermission("leveltools.admin")) {
@@ -101,6 +106,7 @@ public final class LevelToolsPlugin extends JavaPlugin {
       }
 
       reloadConfig();
+      setAnvilCombineMode();
       sender.sendMessage(Text.colorize(Objects.requireNonNull(getConfig().getString("messages.successful_reload"))));
 
       return true;

--- a/src/main/java/me/byteful/plugin/leveltools/LevelToolsUtil.java
+++ b/src/main/java/me/byteful/plugin/leveltools/LevelToolsUtil.java
@@ -6,8 +6,6 @@ import de.tr7zw.changeme.nbtapi.NBTItem;
 import me.byteful.plugin.leveltools.api.item.LevelToolsItem;
 import me.byteful.plugin.leveltools.api.item.impl.NBTLevelToolsItem;
 import me.byteful.plugin.leveltools.api.item.impl.PDCLevelToolsItem;
-import me.lucko.helper.reflect.MinecraftVersion;
-import me.lucko.helper.text3.Text;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -127,14 +125,18 @@ public final class LevelToolsUtil {
         || (RedLib.MID_VERSION >= 14 && material == XMaterial.CROSSBOW.parseMaterial());
   }
 
+  public static boolean isSupportedTool(Material material) {
+    return isPickaxe(material) || isAxe(material) || isShovel(material) || isSword(material) || isProjectileShooter(material);
+  }
+
   public static ItemStack getHand(Player player) {
-    return MinecraftVersion.getRuntimeVersion().isAfterOrEq(MinecraftVersion.parse("1.9"))
+    return RedLib.MID_VERSION >= 9
         ? player.getInventory().getItemInMainHand().clone()
         : player.getItemInHand().clone();
   }
 
   public static void setHand(Player player, ItemStack stack) {
-    if (MinecraftVersion.getRuntimeVersion().isAfterOrEq(MinecraftVersion.parse("1.9"))) {
+    if (RedLib.MID_VERSION >= 9) {
       player.getInventory().setItemInMainHand(stack);
     } else {
       player.setItemInHand(stack);

--- a/src/main/java/me/byteful/plugin/leveltools/Text.java
+++ b/src/main/java/me/byteful/plugin/leveltools/Text.java
@@ -1,0 +1,14 @@
+package me.byteful.plugin.leveltools;
+
+import org.bukkit.ChatColor;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Pulled utility out of lucko's helper library. Since this is pretty much all that was used from helper, I removed the lib to
+ * minimize the size of LevelTools' jar.
+ */
+public final class Text {
+  public static String colorize(@NotNull String string) {
+    return ChatColor.translateAlternateColorCodes('&', string);
+  }
+}

--- a/src/main/java/me/byteful/plugin/leveltools/api/AnvilCombineMode.java
+++ b/src/main/java/me/byteful/plugin/leveltools/api/AnvilCombineMode.java
@@ -3,7 +3,7 @@ package me.byteful.plugin.leveltools.api;
 import me.byteful.plugin.leveltools.model.LevelAndXPModel;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
 
 public enum AnvilCombineMode {
   HIGHER_OF_BOTH((item1, item2) -> {
@@ -65,9 +65,9 @@ public enum AnvilCombineMode {
   });
 
   @NotNull
-  private final BiFunction<LevelAndXPModel, LevelAndXPModel, LevelAndXPModel> handler;
+  private final BinaryOperator<LevelAndXPModel> handler;
 
-  AnvilCombineMode(@NotNull BiFunction<LevelAndXPModel, LevelAndXPModel, LevelAndXPModel> handler) {
+  AnvilCombineMode(@NotNull BinaryOperator<LevelAndXPModel> handler) {
     this.handler = handler;
   }
 
@@ -83,7 +83,7 @@ public enum AnvilCombineMode {
   }
 
   @NotNull
-  public BiFunction<LevelAndXPModel, LevelAndXPModel, LevelAndXPModel> getHandler() {
+  public BinaryOperator<LevelAndXPModel> getHandler() {
     return handler;
   }
 

--- a/src/main/java/me/byteful/plugin/leveltools/api/AnvilCombineMode.java
+++ b/src/main/java/me/byteful/plugin/leveltools/api/AnvilCombineMode.java
@@ -16,12 +16,12 @@ public enum AnvilCombineMode {
     int level;
     double xp;
 
-    if(level1 == level2) {
+    if (level1 == level2) {
       level = level1;
       xp = Math.max(xp1, xp2);
     } else {
       level = Math.max(level1, level2);
-      if(level == level1) {
+      if (level == level1) {
         xp = xp1;
       } else {
         xp = xp2;
@@ -40,12 +40,12 @@ public enum AnvilCombineMode {
     int level;
     double xp;
 
-    if(level1 == level2) {
+    if (level1 == level2) {
       level = level1;
       xp = Math.min(xp1, xp2);
     } else {
       level = Math.min(level1, level2);
-      if(level == level1) {
+      if (level == level1) {
         xp = xp1;
       } else {
         xp = xp2;
@@ -62,8 +62,7 @@ public enum AnvilCombineMode {
     final double xp2 = item2.getXp();
 
     return new LevelAndXPModel(level1 + level2, xp1 + xp2);
-  })
-  ;
+  });
 
   @NotNull
   private final BiFunction<LevelAndXPModel, LevelAndXPModel, LevelAndXPModel> handler;
@@ -73,19 +72,19 @@ public enum AnvilCombineMode {
   }
 
   @NotNull
-  public BiFunction<LevelAndXPModel, LevelAndXPModel, LevelAndXPModel> getHandler() {
-    return handler;
-  }
-
-  @NotNull
   public static AnvilCombineMode fromName(@NotNull String name) {
     for (AnvilCombineMode value : values()) {
-      if(value.name().equalsIgnoreCase(name.replace(" ", "_"))) {
+      if (value.name().equalsIgnoreCase(name.replace(" ", "_"))) {
         return value;
       }
     }
 
     return ADD_BOTH;
+  }
+
+  @NotNull
+  public BiFunction<LevelAndXPModel, LevelAndXPModel, LevelAndXPModel> getHandler() {
+    return handler;
   }
 
   @Override

--- a/src/main/java/me/byteful/plugin/leveltools/api/AnvilCombineMode.java
+++ b/src/main/java/me/byteful/plugin/leveltools/api/AnvilCombineMode.java
@@ -1,0 +1,97 @@
+package me.byteful.plugin.leveltools.api;
+
+import me.byteful.plugin.leveltools.model.LevelAndXPModel;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.BiFunction;
+
+public enum AnvilCombineMode {
+  HIGHER_OF_BOTH((item1, item2) -> {
+    final int level1 = item1.getLevel();
+    final int level2 = item2.getLevel();
+
+    final double xp1 = item1.getXp();
+    final double xp2 = item2.getXp();
+
+    int level;
+    double xp;
+
+    if(level1 == level2) {
+      level = level1;
+      xp = Math.max(xp1, xp2);
+    } else {
+      level = Math.max(level1, level2);
+      if(level == level1) {
+        xp = xp1;
+      } else {
+        xp = xp2;
+      }
+    }
+
+    return new LevelAndXPModel(level, xp);
+  }),
+  LOWER_OF_BOTH((item1, item2) -> {
+    final int level1 = item1.getLevel();
+    final int level2 = item2.getLevel();
+
+    final double xp1 = item1.getXp();
+    final double xp2 = item2.getXp();
+
+    int level;
+    double xp;
+
+    if(level1 == level2) {
+      level = level1;
+      xp = Math.min(xp1, xp2);
+    } else {
+      level = Math.min(level1, level2);
+      if(level == level1) {
+        xp = xp1;
+      } else {
+        xp = xp2;
+      }
+    }
+
+    return new LevelAndXPModel(level, xp);
+  }),
+  ADD_BOTH((item1, item2) -> {
+    final int level1 = item1.getLevel();
+    final int level2 = item2.getLevel();
+
+    final double xp1 = item1.getXp();
+    final double xp2 = item2.getXp();
+
+    return new LevelAndXPModel(level1 + level2, xp1 + xp2);
+  })
+  ;
+
+  @NotNull
+  private final BiFunction<LevelAndXPModel, LevelAndXPModel, LevelAndXPModel> handler;
+
+  AnvilCombineMode(@NotNull BiFunction<LevelAndXPModel, LevelAndXPModel, LevelAndXPModel> handler) {
+    this.handler = handler;
+  }
+
+  @NotNull
+  public BiFunction<LevelAndXPModel, LevelAndXPModel, LevelAndXPModel> getHandler() {
+    return handler;
+  }
+
+  @NotNull
+  public static AnvilCombineMode fromName(@NotNull String name) {
+    for (AnvilCombineMode value : values()) {
+      if(value.name().equalsIgnoreCase(name.replace(" ", "_"))) {
+        return value;
+      }
+    }
+
+    return ADD_BOTH;
+  }
+
+  @Override
+  public String toString() {
+    return "AnvilCombineMode{" +
+        "handler=" + handler +
+        '}';
+  }
+}

--- a/src/main/java/me/byteful/plugin/leveltools/api/event/LevelToolsLevelIncreaseEvent.java
+++ b/src/main/java/me/byteful/plugin/leveltools/api/event/LevelToolsLevelIncreaseEvent.java
@@ -7,7 +7,6 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 public class LevelToolsLevelIncreaseEvent extends Event implements Cancellable {
@@ -32,7 +31,7 @@ public class LevelToolsLevelIncreaseEvent extends Event implements Cancellable {
     this.isCancelled = isCancelled;
   }
 
-  @Nonnull
+  @NotNull
   public static HandlerList getHandlerList() {
     return handlers;
   }
@@ -82,7 +81,7 @@ public class LevelToolsLevelIncreaseEvent extends Event implements Cancellable {
   }
 
   @Override
-  @Nonnull
+  @NotNull
   public HandlerList getHandlers() {
     return handlers;
   }

--- a/src/main/java/me/byteful/plugin/leveltools/api/event/LevelToolsXPIncreaseEvent.java
+++ b/src/main/java/me/byteful/plugin/leveltools/api/event/LevelToolsXPIncreaseEvent.java
@@ -7,7 +7,6 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 public class LevelToolsXPIncreaseEvent extends Event implements Cancellable {
@@ -32,13 +31,13 @@ public class LevelToolsXPIncreaseEvent extends Event implements Cancellable {
     this.isCancelled = isCancelled;
   }
 
-  @Nonnull
+  @NotNull
   public static HandlerList getHandlerList() {
     return handlers;
   }
 
   @Override
-  @Nonnull
+  @NotNull
   public HandlerList getHandlers() {
     return handlers;
   }

--- a/src/main/java/me/byteful/plugin/leveltools/listeners/AnvilListener.java
+++ b/src/main/java/me/byteful/plugin/leveltools/listeners/AnvilListener.java
@@ -20,7 +20,7 @@ public class AnvilListener implements Listener {
     final ItemStack secondItem = inv.getItem(1);
     final ItemStack result = e.getResult();
 
-    if(result == null || !LevelToolsUtil.isSupportedTool(result.getType()) || firstItem == null || secondItem == null || !LevelToolsUtil.isSupportedTool(firstItem.getType()) || !LevelToolsUtil.isSupportedTool(secondItem.getType())) {
+    if (result == null || !LevelToolsUtil.isSupportedTool(result.getType()) || firstItem == null || secondItem == null || !LevelToolsUtil.isSupportedTool(firstItem.getType()) || !LevelToolsUtil.isSupportedTool(secondItem.getType())) {
       return;
     }
 
@@ -42,7 +42,7 @@ public class AnvilListener implements Listener {
     final ItemStack secondItem = inv.getItem(1);
     final ItemStack result = e.getResult();
 
-    if(result == null || !LevelToolsUtil.isSupportedTool(result.getType()) || firstItem == null || secondItem == null || !LevelToolsUtil.isSupportedTool(firstItem.getType())) {
+    if (result == null || !LevelToolsUtil.isSupportedTool(result.getType()) || firstItem == null || secondItem == null || !LevelToolsUtil.isSupportedTool(firstItem.getType())) {
       return;
     }
 

--- a/src/main/java/me/byteful/plugin/leveltools/listeners/AnvilListener.java
+++ b/src/main/java/me/byteful/plugin/leveltools/listeners/AnvilListener.java
@@ -1,0 +1,52 @@
+package me.byteful.plugin.leveltools.listeners;
+
+import me.byteful.plugin.leveltools.LevelToolsPlugin;
+import me.byteful.plugin.leveltools.LevelToolsUtil;
+import me.byteful.plugin.leveltools.api.AnvilCombineMode;
+import me.byteful.plugin.leveltools.api.item.LevelToolsItem;
+import me.byteful.plugin.leveltools.model.LevelAndXPModel;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
+import org.bukkit.inventory.AnvilInventory;
+import org.bukkit.inventory.ItemStack;
+
+public class AnvilListener implements Listener {
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  public void onAnvilCombine(PrepareAnvilEvent e) {
+    final AnvilInventory inv = e.getInventory();
+    final ItemStack firstItem = inv.getItem(0);
+    final ItemStack secondItem = inv.getItem(1);
+    final ItemStack result = e.getResult();
+
+    if(result == null || !LevelToolsUtil.isSupportedTool(result.getType()) || firstItem == null || secondItem == null || !LevelToolsUtil.isSupportedTool(firstItem.getType()) || !LevelToolsUtil.isSupportedTool(secondItem.getType())) {
+      return;
+    }
+
+    final AnvilCombineMode mode = LevelToolsPlugin.getInstance().getAnvilCombineMode();
+    final LevelAndXPModel first = LevelAndXPModel.fromItem(LevelToolsUtil.createLevelToolsItem(firstItem));
+    final LevelAndXPModel second = LevelAndXPModel.fromItem(LevelToolsUtil.createLevelToolsItem(secondItem));
+    final LevelAndXPModel finished = mode.getHandler().apply(first, second);
+    final LevelToolsItem finalItem = LevelToolsUtil.createLevelToolsItem(result);
+    finalItem.setLevel(finished.getLevel());
+    finalItem.setXp(finished.getXp());
+
+    e.setResult(finalItem.getItemStack());
+  }
+
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  public void onAnvilRepair(PrepareAnvilEvent e) {
+    final AnvilInventory inv = e.getInventory();
+    final ItemStack firstItem = inv.getItem(0);
+    final ItemStack secondItem = inv.getItem(1);
+    final ItemStack result = e.getResult();
+
+    if(result == null || !LevelToolsUtil.isSupportedTool(result.getType()) || firstItem == null || secondItem == null || !LevelToolsUtil.isSupportedTool(firstItem.getType())) {
+      return;
+    }
+
+    final LevelToolsItem finalItem = LevelToolsUtil.createLevelToolsItem(result);
+    e.setResult(finalItem.getItemStack()); // This has to be done to patch lore issues.
+  }
+}

--- a/src/main/java/me/byteful/plugin/leveltools/listeners/BlockEventListener.java
+++ b/src/main/java/me/byteful/plugin/leveltools/listeners/BlockEventListener.java
@@ -27,7 +27,7 @@ public class BlockEventListener extends LevelToolsXPListener {
     if (!LevelToolsPlugin.getInstance().getConfig().getBoolean("playerPlacedBlocks")) {
       final DataBlock db = LevelToolsPlugin.getInstance().getBlockDataManager().getDataBlock(block);
 
-      if(db.contains("level_tools") && db.getBoolean("level_tools")) {
+      if (db.contains("level_tools") && db.getBoolean("level_tools")) {
         return;
       }
     }

--- a/src/main/java/me/byteful/plugin/leveltools/listeners/BlockEventListener.java
+++ b/src/main/java/me/byteful/plugin/leveltools/listeners/BlockEventListener.java
@@ -12,7 +12,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 import redempt.redlib.blockdata.DataBlock;
 
-public class BlockEventListener extends LevelToolsListener {
+public class BlockEventListener extends LevelToolsXPListener {
   @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
   public void onBlockBreak(BlockBreakEvent e) {
     final Player player = e.getPlayer();

--- a/src/main/java/me/byteful/plugin/leveltools/listeners/EntityEventListener.java
+++ b/src/main/java/me/byteful/plugin/leveltools/listeners/EntityEventListener.java
@@ -9,7 +9,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
 
-public class EntityEventListener extends LevelToolsListener {
+public class EntityEventListener extends LevelToolsXPListener {
   @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
   public void onEntityKillEntity(EntityDeathEvent e) {
     Player killer = e.getEntity().getKiller();

--- a/src/main/java/me/byteful/plugin/leveltools/listeners/LevelToolsXPListener.java
+++ b/src/main/java/me/byteful/plugin/leveltools/listeners/LevelToolsXPListener.java
@@ -3,11 +3,10 @@ package me.byteful.plugin.leveltools.listeners;
 import com.cryptomorin.xseries.XEnchantment;
 import me.byteful.plugin.leveltools.LevelToolsPlugin;
 import me.byteful.plugin.leveltools.LevelToolsUtil;
+import me.byteful.plugin.leveltools.Text;
 import me.byteful.plugin.leveltools.api.event.LevelToolsLevelIncreaseEvent;
 import me.byteful.plugin.leveltools.api.event.LevelToolsXPIncreaseEvent;
 import me.byteful.plugin.leveltools.api.item.LevelToolsItem;
-import me.lucko.helper.Events;
-import me.lucko.helper.text3.Text;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.apache.commons.lang.math.NumberUtils;
@@ -23,14 +22,14 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
-public abstract class LevelToolsListener implements Listener {
+public abstract class LevelToolsXPListener implements Listener {
   protected void handle(LevelToolsItem tool, Player player, double modifier) {
     double newXp = LevelToolsUtil.round(tool.getXp() + modifier, 1);
 
     final LevelToolsXPIncreaseEvent xpEvent =
         new LevelToolsXPIncreaseEvent(tool, player, newXp, false);
 
-    Events.call(xpEvent);
+    Bukkit.getPluginManager().callEvent(xpEvent);
 
     if (xpEvent.isCancelled()) {
       return;

--- a/src/main/java/me/byteful/plugin/leveltools/model/LevelAndXPModel.java
+++ b/src/main/java/me/byteful/plugin/leveltools/model/LevelAndXPModel.java
@@ -1,5 +1,6 @@
 package me.byteful.plugin.leveltools.model;
 
+import me.byteful.plugin.leveltools.LevelToolsUtil;
 import me.byteful.plugin.leveltools.api.item.LevelToolsItem;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,7 +12,7 @@ public final class LevelAndXPModel {
 
   public LevelAndXPModel(int level, double xp) {
     this.level = level;
-    this.xp = xp;
+    this.xp = LevelToolsUtil.round(xp, 1);
   }
 
   @NotNull

--- a/src/main/java/me/byteful/plugin/leveltools/model/LevelAndXPModel.java
+++ b/src/main/java/me/byteful/plugin/leveltools/model/LevelAndXPModel.java
@@ -1,0 +1,50 @@
+package me.byteful.plugin.leveltools.model;
+
+import me.byteful.plugin.leveltools.api.item.LevelToolsItem;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public final class LevelAndXPModel {
+  private final int level;
+  private final double xp;
+
+  public LevelAndXPModel(int level, double xp) {
+    this.level = level;
+    this.xp = xp;
+  }
+
+  @NotNull
+  public static LevelAndXPModel fromItem(@NotNull LevelToolsItem item) {
+    return new LevelAndXPModel(item.getLevel(), item.getXp());
+  }
+
+  public int getLevel() {
+    return level;
+  }
+
+  public double getXp() {
+    return xp;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LevelAndXPModel that = (LevelAndXPModel) o;
+    return level == that.level && Double.compare(that.xp, xp) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(level, xp);
+  }
+
+  @Override
+  public String toString() {
+    return "LevelAndXPModel{" +
+        "level=" + level +
+        ", xp=" + xp +
+        '}';
+  }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,8 +7,9 @@ messages:
   no_permission: "&cYou do not have permission to execute this command!"
   successful_reload: "&aSuccessfully reloaded LevelTools!"
 
-# @Deprecated
-#level_multiplier: 100.0
+# What action should be done when combining items in an anvil?
+# Modes: "HIGHER_OF_BOTH" (Takes level and xp of higher level item), "LOWER_OF_BOTH" (Takes level and xp of lower level item), OR "ADD_BOTH" (Adds the level and XP of both items)
+anvil_combine: "ADD_BOTH"
 
 # The amount of XP needed to get from level 0 to level 1.
 level_xp_start: 100.0

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,10 @@ author: byteful
 description: "A plugin that adds a leveling system to tools, swords, and bows."
 website: "https://byteful.me"
 api-version: "1.14"
+commands:
+  lt-reload:
+    description: "Reloads LevelTools's configuration."
+    permission: "leveltools.admin"
 permissions:
   leveltools.admin:
     description: "Permission to use admin commands."


### PR DESCRIPTION
New config value for anvil combine mode:
```yml
# What action should be done when combining items in an anvil?
# Modes: "HIGHER_OF_BOTH" (Takes level and xp of higher level item), "LOWER_OF_BOTH" (Takes level and xp of lower level item), OR "ADD_BOTH" (Adds the level and XP of both items)
anvil_combine: "ADD_BOTH"
```