### PR TITLE
Change all event handlers to MONITOR priority

### DIFF
--- a/src/main/java/me/byteful/plugin/leveltools/listeners/AnvilListener.java
+++ b/src/main/java/me/byteful/plugin/leveltools/listeners/AnvilListener.java
@@ -13,7 +13,7 @@ import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.ItemStack;
 
 public class AnvilListener implements Listener {
-  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
   public void onAnvilCombine(PrepareAnvilEvent e) {
     final AnvilInventory inv = e.getInventory();
     final ItemStack firstItem = inv.getItem(0);
@@ -42,7 +42,7 @@ public class AnvilListener implements Listener {
     e.setResult(finalItem.getItemStack());
   }
 
-  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
   public void onAnvilRepair(PrepareAnvilEvent e) {
     final AnvilInventory inv = e.getInventory();
     final ItemStack firstItem = inv.getItem(0);

--- a/src/main/java/me/byteful/plugin/leveltools/listeners/AnvilListener.java
+++ b/src/main/java/me/byteful/plugin/leveltools/listeners/AnvilListener.java
@@ -13,7 +13,7 @@ import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.ItemStack;
 
 public class AnvilListener implements Listener {
-  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onAnvilCombine(PrepareAnvilEvent e) {
     final AnvilInventory inv = e.getInventory();
     final ItemStack firstItem = inv.getItem(0);
@@ -42,7 +42,7 @@ public class AnvilListener implements Listener {
     e.setResult(finalItem.getItemStack());
   }
 
-  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onAnvilRepair(PrepareAnvilEvent e) {
     final AnvilInventory inv = e.getInventory();
     final ItemStack firstItem = inv.getItem(0);

--- a/src/main/java/me/byteful/plugin/leveltools/listeners/BlockEventListener.java
+++ b/src/main/java/me/byteful/plugin/leveltools/listeners/BlockEventListener.java
@@ -13,7 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import redempt.redlib.blockdata.DataBlock;
 
 public class BlockEventListener extends LevelToolsXPListener {
-  @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onBlockBreak(BlockBreakEvent e) {
     final Player player = e.getPlayer();
 
@@ -50,7 +50,7 @@ public class BlockEventListener extends LevelToolsXPListener {
     }
   }
 
-  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onBlockPlace(BlockPlaceEvent e) {
     if (!LevelToolsPlugin.getInstance().getConfig().getBoolean("playerPlacedBlocks")) {
       LevelToolsPlugin.getInstance()

--- a/src/main/java/me/byteful/plugin/leveltools/listeners/EntityEventListener.java
+++ b/src/main/java/me/byteful/plugin/leveltools/listeners/EntityEventListener.java
@@ -10,7 +10,7 @@ import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
 
 public class EntityEventListener extends LevelToolsXPListener {
-  @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onEntityKillEntity(EntityDeathEvent e) {
     Player killer = e.getEntity().getKiller();
 


### PR DESCRIPTION
This means that leveltools will respect all protection plugins, as some use EventPriority.HIGHEST, causing them to be ignored by leveltools

It might also have some improved performance, idk how bukkit events work